### PR TITLE
Add link to JabRef

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DTK-Bibliography
 
-A project by Leo Arnold and Uwe Ziegenhagen to create an updated version of Dante's DTK bibliography. The bib file can also be used with Jabref (which also has some nice export functions, see the HTML file below)
+A project by Leo Arnold and Uwe Ziegenhagen to create an updated version of Dante's DTK bibliography. The bib file can also be used with [JabRef](https://www.jabref.org/) (which also has some nice export functions, see the HTML file below)
 
 [![Build Status](https://travis-ci.org/dante-ev/dtk-bibliography.svg)](https://travis-ci.org/dante-ev/dtk-bibliography)
 


### PR DESCRIPTION
Fix typo in JabRef's name and add a link to its homepage.

Thank you for mentioning ❤️ 